### PR TITLE
faster parse_snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 Manifest.toml
+*.heapsnapshot

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ using Profile
 Profile.take_heap_snapshot("foo.heapsnapshot")
 
 using HeapSnapshotParser
-s = HeapSnapshotParser.parse_snapshot(open("foo.heapsnapshot"))
+s = HeapSnapshotParser.parse_snapshot("foo.heapsnapshot")
 ```

--- a/src/HeapSnapshotParser.jl
+++ b/src/HeapSnapshotParser.jl
@@ -4,26 +4,28 @@ using JSON
 using LightGraphs
 using StructEquality
 
-@struct_hash_equal Base.@kwdef struct Node
-    kind::Symbol
-    type::String
-    id::Int
-    num_edges::Int
-    self_size::Int
+@struct_hash_equal Base.@kwdef mutable struct Node
+    kind::Union{Symbol,Nothing} = nothing
+    type::Union{String,Nothing} = nothing
+    id::Union{Int,Nothing} = nothing
+    num_edges::Union{Int,Nothing} = nothing
+    self_size::Union{Int,Nothing} = nothing
 
     # index into snapshot.edges
     # would be an array of indexes, but Julia doesn't
     # support types which refer to each other :facepalm:
     # https://github.com/JuliaLang/julia/issues/269
-    out_edge_indexes::Array{Int}
+    out_edge_indexes::Array{Int} = Int[]
 end
 
-@struct_hash_equal Base.@kwdef struct Edge
-    kind::Symbol
-    name::String
+dummy_node = Node()
 
-    from::Node
-    to::Node
+@struct_hash_equal Base.@kwdef mutable struct Edge
+    kind::Symbol = :null
+    name::String = ""
+
+    from::Node = dummy_node
+    to::Node = dummy_node
 end
 
 Base.@kwdef struct HeapSnapshot
@@ -37,8 +39,11 @@ NUM_NODE_FIELDS = length(NODE_FIElDS)
 EDGE_FIELDS = ["type", "name_or_index", "to_node"]
 NUM_EDGE_FIELDS = length(EDGE_FIELDS)
 
-function parse_snapshot(input::IOStream)::HeapSnapshot
-    parsed = JSON.parse(input)
+function parse_snapshot(file::String)::HeapSnapshot
+
+    # JSON.parsefile is faster than JSON.parse because it uses mmap
+    parsed = JSON.parsefile(file)
+
     snapshot = HeapSnapshot(nodes=[], edges=[])
 
     node_kind_enum = parsed["snapshot"]["meta"]["node_types"][1]
@@ -47,29 +52,41 @@ function parse_snapshot(input::IOStream)::HeapSnapshot
     nodes = parsed["nodes"]
     strings = parsed["strings"]
     num_nodes = convert(Int, length(nodes)/NUM_NODE_FIELDS)
-    for node_idx = 0:(num_nodes-1)
+
+    all_num_edges = Vector{Int}(undef, num_nodes + 1)
+    all_num_edges[1] = 0
+    num_edges_accum = Vector{Int}(undef, num_nodes + 1)
+
+    append!(snapshot.nodes, map(_->Node(), 1:num_nodes))
+
+    Threads.@threads for node_idx = 0:(num_nodes-1)
         kind_key = nodes[node_idx*NUM_NODE_FIELDS + 1]
         name_key = nodes[node_idx*NUM_NODE_FIELDS + 2]
         id = nodes[node_idx*NUM_NODE_FIELDS + 3]
         self_size = nodes[node_idx*NUM_NODE_FIELDS + 4]
         num_edges = nodes[node_idx*NUM_NODE_FIELDS + 5]
 
-        node = Node(
-            kind=Symbol(node_kind_enum[kind_key + 1]),
-            type=strings[name_key + 1],
-            num_edges=num_edges,
-            self_size=self_size,
-            out_edge_indexes=[], # filled in below
-            id=id,
-        )
+        node = snapshot.nodes[node_idx + 1]
+        node.kind = Symbol(node_kind_enum[kind_key + 1])
+        node.type = strings[name_key + 1]
+        node.num_edges = num_edges
+        node.self_size = self_size
+        node.out_edge_indexes = [] # filled in below
+        node.id = id
 
-        push!(snapshot.nodes, node)
+        all_num_edges[node_idx + 2] = num_edges
+    end
+    cumsum!(num_edges_accum, all_num_edges)
+
+    for _ in 1:num_edges_accum[end]
+        push!(snapshot.edges, Edge())
     end
 
     edges = parsed["edges"]
-    edge_idx = 0
-    for from_node in snapshot.nodes
+    Threads.@threads for (node_i, from_node) in collect(enumerate(snapshot.nodes))
         for edge_num = 1:(from_node.num_edges)
+            edge_idx = num_edges_accum[node_i] + (edge_num - 1)
+
             kind_key = edges[edge_idx*NUM_EDGE_FIELDS + 1]
             name_key = edges[edge_idx*NUM_EDGE_FIELDS + 2]
             to_key = edges[edge_idx*NUM_EDGE_FIELDS + 3]
@@ -86,16 +103,13 @@ function parse_snapshot(input::IOStream)::HeapSnapshot
                 strings[name_key+1]
             end
 
-            edge = Edge(
-                kind=kind,
-                name=name,
-                from=from_node,
-                to=snapshot.nodes[to_node_idx],
-            )
+            edge = snapshot.edges[edge_idx + 1]
+            edge.kind = kind
+            edge.name = name
+            edge.from = from_node
+            edge.to = snapshot.nodes[to_node_idx]
 
-            push!(snapshot.edges, edge)
-            push!(from_node.out_edge_indexes, length(snapshot.edges))
-            edge_idx += 1
+            push!(from_node.out_edge_indexes, edge_idx)
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,5 @@ using HeapSnapshotParser
 # TODO: make this into an actual unit test
 # at the moment just testing that it doesn't explode
 
-open("../testdata/empty-repl.heapsnapshot") do f
-    HeapSnapshotParser.parse_snapshot(f)
-end
+HeapSnapshotParser.parse_snapshot("../testdata/empty-repl.heapsnapshot")
+


### PR DESCRIPTION
Fixes #9 (or helps it quite a bit)

This is on a machine with 16 cores, so an extreme example.

PR
```
julia> using Profile

julia> @time fp = Profile.take_heap_snapshot()
  3.220156 seconds (38 allocations: 3.188 KiB, 55.80% gc time)
"/home/ian/Documents/GitHub/julia/1808736_1665024562528373.heapsnapshot"

julia> using HeapSnapshotParser

julia> @time HeapSnapshotParser.parse_snapshot(fp);
  4.064810 seconds (120.69 M allocations: 2.970 GiB, 33.66% gc time, 41.68% compilation time)

julia> @time HeapSnapshotParser.parse_snapshot(fp);
  3.861502 seconds (120.45 M allocations: 2.955 GiB, 37.69% gc time)
```

master
```
julia> @time HeapSnapshotParser.parse_snapshot(open("/home/ian/Documents/GitHub/julia/1808736_1665024562528373.heapsnapshot"));
 13.215142 seconds (120.02 M allocations: 4.981 GiB, 17.67% gc time, 1.12% compilation time)

julia> @time HeapSnapshotParser.parse_snapshot(open("/home/ian/Documents/GitHub/julia/1808736_1665024562528373.heapsnapshot"));
 12.059683 seconds (119.94 M allocations: 5.350 GiB, 13.30% gc time)
```
